### PR TITLE
doc: Replaced various quotation encodings in file headers

### DIFF
--- a/access-control/cpp/src/access-control.cpp
+++ b/access-control/cpp/src/access-control.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/access-control/javascript/datastore.js
+++ b/access-control/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/access-control/javascript/index.js
+++ b/access-control/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/access-control/javascript/mqtt.js
+++ b/access-control/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/air-quality-sensor/cpp/src/air-quality-sensor.cpp
+++ b/air-quality-sensor/cpp/src/air-quality-sensor.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/air-quality-sensor/javascript/datastore.js
+++ b/air-quality-sensor/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/air-quality-sensor/javascript/index.js
+++ b/air-quality-sensor/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/air-quality-sensor/javascript/mqtt.js
+++ b/air-quality-sensor/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/alarm-clock/cpp/src/alarm-clock.cpp
+++ b/alarm-clock/cpp/src/alarm-clock.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/alarm-clock/javascript/datastore.js
+++ b/alarm-clock/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/alarm-clock/javascript/index.js
+++ b/alarm-clock/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/alarm-clock/javascript/mqtt.js
+++ b/alarm-clock/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/ble-scan-bracelet/cpp/src/ble-scan.cpp
+++ b/ble-scan-bracelet/cpp/src/ble-scan.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/ble-scan-bracelet/javascript/datastore.js
+++ b/ble-scan-bracelet/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/ble-scan-bracelet/javascript/index.js
+++ b/ble-scan-bracelet/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/ble-scan-bracelet/javascript/mqtt.js
+++ b/ble-scan-bracelet/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/close-call-reporter/cpp/src/close-call-reporter.cpp
+++ b/close-call-reporter/cpp/src/close-call-reporter.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/close-call-reporter/javascript/datastore.js
+++ b/close-call-reporter/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/close-call-reporter/javascript/index.js
+++ b/close-call-reporter/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/close-call-reporter/javascript/mqtt.js
+++ b/close-call-reporter/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/doorbell/cpp/src/doorbell.cpp
+++ b/doorbell/cpp/src/doorbell.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/doorbell/javascript/datastore.js
+++ b/doorbell/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/doorbell/javascript/index.js
+++ b/doorbell/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/doorbell/javascript/mqtt.js
+++ b/doorbell/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/earthquake-detector/cpp/src/earthquake-detector.cpp
+++ b/earthquake-detector/cpp/src/earthquake-detector.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/equipment-activity-monitor/cpp/src/equipment-activity.cpp
+++ b/equipment-activity-monitor/cpp/src/equipment-activity.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/equipment-activity-monitor/javascript/datastore.js
+++ b/equipment-activity-monitor/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/equipment-activity-monitor/javascript/index.js
+++ b/equipment-activity-monitor/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/equipment-activity-monitor/javascript/mqtt.js
+++ b/equipment-activity-monitor/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/field-data-reporter/cpp/src/field-data.cpp
+++ b/field-data-reporter/cpp/src/field-data.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/field-data-reporter/javascript/index.js
+++ b/field-data-reporter/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/fire-alarm/cpp/src/fire-alarm.cpp
+++ b/fire-alarm/cpp/src/fire-alarm.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/fire-alarm/javascript/datastore.js
+++ b/fire-alarm/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/fire-alarm/javascript/index.js
+++ b/fire-alarm/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/fire-alarm/javascript/mqtt.js
+++ b/fire-alarm/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/home-fall-tracker/cpp/src/fall-tracker.cpp
+++ b/home-fall-tracker/cpp/src/fall-tracker.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/home-fall-tracker/javascript/datastore.js
+++ b/home-fall-tracker/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/home-fall-tracker/javascript/index.js
+++ b/home-fall-tracker/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/home-fall-tracker/javascript/mqtt.js
+++ b/home-fall-tracker/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/line-following-robot/cpp/src/line-finder-robot.cpp
+++ b/line-following-robot/cpp/src/line-finder-robot.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/line-following-robot/javascript/datastore.js
+++ b/line-following-robot/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/line-following-robot/javascript/index.js
+++ b/line-following-robot/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/line-following-robot/javascript/mqtt.js
+++ b/line-following-robot/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/plant-lighting-system/cpp/src/plant-lighting-system.cpp
+++ b/plant-lighting-system/cpp/src/plant-lighting-system.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/plant-lighting-system/javascript/datastore.js
+++ b/plant-lighting-system/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/plant-lighting-system/javascript/index.js
+++ b/plant-lighting-system/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/plant-lighting-system/javascript/mqtt.js
+++ b/plant-lighting-system/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/range-finder-scanner/cpp/src/range-finder-scanner.cpp
+++ b/range-finder-scanner/cpp/src/range-finder-scanner.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/range-finder-scanner/javascript/index.js
+++ b/range-finder-scanner/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/robot-arm/cpp/src/robot-arm.cpp
+++ b/robot-arm/cpp/src/robot-arm.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/robot-arm/javascript/index.js
+++ b/robot-arm/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/smart-stove-top/cpp/src/smart-stovetop.cpp
+++ b/smart-stove-top/cpp/src/smart-stovetop.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/smart-stove-top/javascript/datastore.js
+++ b/smart-stove-top/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/smart-stove-top/javascript/index.js
+++ b/smart-stove-top/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/smart-stove-top/javascript/mqtt.js
+++ b/smart-stove-top/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/storage-unit-flood-detector/cpp/src/storage-unit-flood-detector.cpp
+++ b/storage-unit-flood-detector/cpp/src/storage-unit-flood-detector.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/storage-unit-flood-detector/javascript/datastore.js
+++ b/storage-unit-flood-detector/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/storage-unit-flood-detector/javascript/index.js
+++ b/storage-unit-flood-detector/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/storage-unit-flood-detector/javascript/mqtt.js
+++ b/storage-unit-flood-detector/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/watering-system/cpp/src/watering-system.cpp
+++ b/watering-system/cpp/src/watering-system.cpp
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/watering-system/javascript/datastore.js
+++ b/watering-system/javascript/datastore.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/watering-system/javascript/index.js
+++ b/watering-system/javascript/index.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,

--- a/watering-system/javascript/mqtt.js
+++ b/watering-system/javascript/mqtt.js
@@ -1,7 +1,7 @@
 /*
 * Copyright (c) 2015-2016 Intel Corporation.
 *
-* Permission is hereby granted, free of charge, to any person (“User”) obtaining
+* Permission is hereby granted, free of charge, to any person ("User") obtaining
 * a copy of this software and associated documentation files (the
 * "Software"), to deal in the Software without restriction, including
 * without limitation the rights to use, copy, modify, merge, publish,


### PR DESCRIPTION
Small change - standardized encoding for quotations on "User" in
file headers.  There were 2 different non-utf8 encodings around the
word User which has a possibility of causing complaints with some text
tools.  Example, Ubuntu greb would NOT search these files by default
since the non-utf8 encodings flag the file as binary.

Replaced all instances with "User".

Signed-off-by: Noel Eck <noel.eck@intel.com>