### PR TITLE
upm: Update sample source with new upm headers (.h -> .hpp)

### DIFF
--- a/access-control/cpp/src/access-control.cpp
+++ b/access-control/cpp/src/access-control.cpp
@@ -65,7 +65,7 @@
 #include <string>
 
 #include <jhd1313m1.h>
-#include "biss0001.h"
+#include "biss0001.hpp"
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"
 

--- a/air-quality-sensor/cpp/src/air-quality-sensor.cpp
+++ b/air-quality-sensor/cpp/src/air-quality-sensor.cpp
@@ -64,7 +64,7 @@
 #include <string>
 #include <signal.h>
 
-#include <grovespeaker.h>
+#include <grovespeaker.hpp>
 #include "tp401.h"
 
 #define WARNING_THRESHOLD 200

--- a/alarm-clock/cpp/src/alarm-clock.cpp
+++ b/alarm-clock/cpp/src/alarm-clock.cpp
@@ -64,8 +64,8 @@
 #include <thread>
 #include <ctime>
 
-#include <grove.h>
-#include <buzzer.h>
+#include <grove.hpp>
+#include <buzzer.hpp>
 #include <jhd1313m1.h>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"

--- a/close-call-reporter/cpp/src/close-call-reporter.cpp
+++ b/close-call-reporter/cpp/src/close-call-reporter.cpp
@@ -62,8 +62,8 @@
 #include <string>
 #include <signal.h>
 
-#include <ublox6.h>
-#include <rfr359f.h>
+#include <ublox6.hpp>
+#include <rfr359f.hpp>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"
 

--- a/doorbell/cpp/src/doorbell.cpp
+++ b/doorbell/cpp/src/doorbell.cpp
@@ -61,8 +61,8 @@
 #include <sstream>
 #include <signal.h>
 
-#include <ttp223.h>
-#include <buzzer.h>
+#include <ttp223.hpp>
+#include <buzzer.hpp>
 #include <jhd1313m1.h>
 
 #include "datastore.h"

--- a/earthquake-detector/cpp/src/earthquake-detector.cpp
+++ b/earthquake-detector/cpp/src/earthquake-detector.cpp
@@ -59,7 +59,7 @@
 #include <ctime>
 #include <signal.h>
 
-#include <mma7660.h>
+#include <mma7660.hpp>
 #include <jhd1313m1.h>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"

--- a/equipment-activity-monitor/cpp/src/equipment-activity.cpp
+++ b/equipment-activity-monitor/cpp/src/equipment-activity.cpp
@@ -63,8 +63,8 @@
 #include <ctime>
 #include <signal.h>
 
-#include <mic.h>
-#include <ldt0028.h>
+#include <mic.hpp>
+#include <ldt0028.hpp>
 #include <jhd1313m1.h>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"

--- a/field-data-reporter/cpp/src/field-data.cpp
+++ b/field-data-reporter/cpp/src/field-data.cpp
@@ -62,7 +62,7 @@
 #include <ctime>
 
 #include <ssd1308.h>
-#include <at42qt1070.h>
+#include <at42qt1070.hpp>
 #include <bmpx8x.h>
 #define OLED_DEVICE_ADDRESS    0x3C
 #define OLED_BUS_NUMBER        0x0

--- a/fire-alarm/cpp/src/fire-alarm.cpp
+++ b/fire-alarm/cpp/src/fire-alarm.cpp
@@ -63,8 +63,8 @@
 #include <vector>
 #include <signal.h>
 
-#include <grove.h>
-#include <buzzer.h>
+#include <grove.hpp>
+#include <buzzer.hpp>
 #include <jhd1313m1.h>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"

--- a/home-fall-tracker/cpp/src/fall-tracker.cpp
+++ b/home-fall-tracker/cpp/src/fall-tracker.cpp
@@ -67,7 +67,7 @@ using std::vector;
 #include <ssd1308.h>
 #define OLED_DEVICE_ADDRESS    0x3C
 #define OLED_BUS_NUMBER        0x0
-#include <adxl345.h>
+#include <adxl345.hpp>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"
 

--- a/line-following-robot/cpp/src/line-finder-robot.cpp
+++ b/line-following-robot/cpp/src/line-finder-robot.cpp
@@ -64,8 +64,8 @@
 #include <ctime>
 #include <signal.h>
 
-#include <grovelinefinder.h>
-#include <uln200xa.h>
+#include <grovelinefinder.hpp>
+#include <uln200xa.hpp>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"
 

--- a/plant-lighting-system/cpp/src/plant-lighting-system.cpp
+++ b/plant-lighting-system/cpp/src/plant-lighting-system.cpp
@@ -65,9 +65,9 @@ using std::string;
 #include <vector>
 using std::vector;
 
-#include "grove.h"
+#include "grove.hpp"
 #include <jhd1313m1.h>
-#include <grovemoisture.h>
+#include <grovemoisture.hpp>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"
 

--- a/range-finder-scanner/cpp/src/range-finder-scanner.cpp
+++ b/range-finder-scanner/cpp/src/range-finder-scanner.cpp
@@ -65,8 +65,8 @@
 #include <array>
 #include <string>
 
-#include <uln200xa.h>
-#include <rfr359f.h>
+#include <uln200xa.hpp>
+#include <rfr359f.hpp>
 
 #include "../lib/crow/crow_all.h"
 #include "html.h"

--- a/robot-arm/cpp/src/robot-arm.cpp
+++ b/robot-arm/cpp/src/robot-arm.cpp
@@ -65,8 +65,8 @@
 #include <signal.h>
 #include <math.h>
 
-#include <uln200xa.h>
-#include <joystick12.h>
+#include <uln200xa.hpp>
+#include <joystick12.hpp>
 
 #include "html.h"
 #include "css.h"

--- a/smart-stove-top/cpp/src/smart-stovetop.cpp
+++ b/smart-stove-top/cpp/src/smart-stovetop.cpp
@@ -58,10 +58,10 @@
 #include <string>
 #include <signal.h>
 
-#include <grove.h>
-#include <yg1006.h>
-#include <otp538u.h>
-#include <grovespeaker.h>
+#include <grove.hpp>
+#include <yg1006.hpp>
+#include <otp538u.hpp>
+#include <grovespeaker.hpp>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"
 #include "datastore.h"

--- a/storage-unit-flood-detector/cpp/src/storage-unit-flood-detector.cpp
+++ b/storage-unit-flood-detector/cpp/src/storage-unit-flood-detector.cpp
@@ -59,9 +59,9 @@
 #include <ctime>
 #include <sstream>
 
-#include <grove.h>
-#include <grovemoisture.h>
-#include <grovespeaker.h>
+#include <grove.hpp>
+#include <grovemoisture.hpp>
+#include <grovespeaker.hpp>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"
 

--- a/watering-system/cpp/src/watering-system.cpp
+++ b/watering-system/cpp/src/watering-system.cpp
@@ -69,8 +69,8 @@ using std::string;
 using std::vector;
 
 #include <mraa.hpp>
-#include <grovewfs.h>
-#include <grovemoisture.h>
+#include <grovewfs.hpp>
+#include <grovemoisture.hpp>
 
 #include "../lib/restclient-cpp/include/restclient-cpp/restclient.h"
 


### PR DESCRIPTION
UPM C++ headers have been renamed to make room for adding C sources.
Header files changed from .h to .hpp.  Updating sample source to
work with the new UPM header names